### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,5 @@ updates:
       time: "06:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: "grpc-api"


### PR DESCRIPTION
Exclude grpc upates for now until zeebe supports the newest version